### PR TITLE
Fix: Correct handling of selected indices in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,7 +139,7 @@ def handle_generate_audio_subtitles(
     generation_log = "Starting generation process...\n"
     output_links_markdown = ""
 
-    if selected_indices is None or not selected_indices['index']: # Check if selection event data is valid
+    if not selected_indices: # Check if selection event data is valid (now expects a list)
         generation_log += "No news items selected for generation.\n"
         return generation_log, ""
 


### PR DESCRIPTION
Changed the condition for checking selected items in `handle_generate_audio_subtitles` to correctly process the list of row indices from DataFrame selections. This resolves a TypeError that occurred when trying to access `selected_indices['index']` on a list object.