### PR TITLE
fix: Refactor Minimax TTS to use HTTP streaming

### DIFF
--- a/PDD.md
+++ b/PDD.md
@@ -35,9 +35,10 @@
         *   Google Cloud Text-to-Speech API (requires user API key/credentials).
         *   Minimax TTS API:
             *   Requires user API key and Group ID (configured via `.env`).
-            *   Utilizes the `speech-02-hd` model for generation.
-            *   The default voice is "Boyan_new_platform". *Note: The UI's 'Select Voice Gender' option does not currently change the Minimax voice.*
-            *   Generates audio in MP3 format (32000 Hz sample rate, 128 kbps bitrate, as per current implementation defaults).
+            *   Accessed via an HTTP streaming interface.
+            *   Utilizes the `speech-02-turbo` model for generation.
+            *   The default voice is "male-qn-qingse". *Note: The UI's 'Select Voice Gender' option does not currently change the Minimax voice; the default 'male-qn-qingse' is used.*
+            *   Generates audio in MP3 format (32000 Hz sample rate, 128 kbps bitrate, mono channel, as per current implementation defaults).
     *   Output filenames will follow the convention: `YYYYMMDDHHMMSS_Topic_News.extension` (e.g., `20231027103000_AI_News.mp3`). If no topic is specified, it will be `YYYYMMDDHHMMSS_News.extension`.
 *   **Subtitle Generation:**
     *   Formats: SRT (.srt) and LRC (.lrc).


### PR DESCRIPTION
This commit significantly refactors the Minimax Text-to-Speech (TTS) implementation in `tts_generator.py` to correctly use HTTP streaming, based on updated API usage examples. The previous non-streaming HTTP POST method was insufficient for the actual API behavior, which involves processing a stream of JSON objects containing hex-encoded audio data.

Key changes to `_generate_minimax_tts`:
- Implemented HTTP POST request with `stream=True`.
- Set appropriate headers, including 'accept' for streaming.
- Updated the request body to use the "speech-02-turbo" model and "male-qn-qingse" voice by default, with `stream: True`.
- Processed the response by iterating over lines (`response.iter_lines()`):
  - Stripped `data:` prefix from relevant lines.
  - Parsed JSON content from each line.
  - Extracted hex-encoded audio strings from `data['data']['audio']`.
  - Decoded hex strings to bytes using `bytes.fromhex()`.
  - Accumulated all audio byte chunks.
- Saved the complete concatenated audio bytes to the output file.
- Enhanced error handling for initial HTTP errors (e.g., 4xx/5xx), errors within the stream, JSON decoding errors, and hex decoding errors.
- The UI's voice gender selection remains ignored for Minimax, defaulting to "male-qn-qingse".

PDD Update:
- `PDD.md` was updated to reflect these changes: HTTP streaming interaction, the "speech-02-turbo" model, "male-qn-qingse" default voice, and relevant audio settings.

This change addresses the previously reported error where Minimax TTS would return a status 200 but the content was not directly usable audio, and provides a more accurate implementation based on the API's streaming and data encoding behavior.