### PR TITLE
feat: Implement translation using local Ollama service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,5 @@ GOOGLE_CLOUD_TTS_CREDENTIALS_PATH="" # Path to your Google Cloud service account
 MINIMAX_API_KEY=""
 MINIMAX_GROUP_ID=""
 
-# Translation API Key (Add your specific translation service key here)
-# Example: If using Google Translate API, this would be your Google Cloud API Key
-# (though it might be the same as used for TTS if services are bundled)
-TRANSLATION_API_KEY=""
+# Note: TRANSLATION_API_KEY was previously here for Google Translate.
+# Translation is now handled via Ollama, which uses OLLAMA_API_BASE_URL and a model specified in the UI.

--- a/app.py
+++ b/app.py
@@ -66,8 +66,8 @@ env_vars_to_check = [
     "GEMINI_API_KEY", "OPENROUTER_API_KEY", "OLLAMA_API_BASE_URL",
     "AZURE_TTS_API_KEY", "AZURE_TTS_REGION", 
     "GOOGLE_CLOUD_TTS_CREDENTIALS_PATH",
-    "MINIMAX_API_KEY", "MINIMAX_GROUP_ID",
-    "TRANSLATION_API_KEY" # Added Translation API Key
+    "MINIMAX_API_KEY", "MINIMAX_GROUP_ID"
+    # "TRANSLATION_API_KEY" # Removed as Ollama is used for translation
 ]
 for var_name in env_vars_to_check:
     if os.getenv(var_name):
@@ -248,14 +248,15 @@ def handle_generate_audio_subtitles(
         
         # Actual Translation Step
         if target_lang_code_for_processing:
-            logger.info(f"Attempting translation of item '{original_title}' to {target_lang_code_for_processing}...")
-            current_translation_api_key = os.getenv("TRANSLATION_API_KEY") # Using os.getenv for now
+            logger.info(f"Attempting translation of item '{original_title}' to {target_lang_code_for_processing} using Ollama model '{ollama_model_name}' at URL '{ollama_api_url_cfg}'...")
+            # current_translation_api_key = os.getenv("TRANSLATION_API_KEY") # No longer needed for Ollama
             
             translation_result = translator.translate_text(
                 text=text_for_tts,
                 target_lang_code=target_lang_code_for_processing,
                 source_lang_code="auto", # Or a fixed source like "en"
-                api_key=current_translation_api_key 
+                ollama_model=ollama_model_name, # Pass the Ollama model name from UI
+                ollama_api_url=ollama_api_url_cfg  # Pass the Ollama API URL from UI config
             )
             if translation_result['error']:
                 logger.error(f"Translation Error for item '{original_title}': {translation_result['error']}")
@@ -627,16 +628,7 @@ with gr.Blocks(theme=gr.themes.Soft(), title="News Aggregator & Audio/Subtitle G
                 with gr.Column():
                     cfg_minimax_key = gr.Textbox(label="Minimax API Key (TTS)", type="password", lines=1, value=os.getenv("MINIMAX_API_KEY", ""))
                     cfg_minimax_group_id = gr.Textbox(label="Minimax Group ID (TTS)", lines=1, value=os.getenv("MINIMAX_GROUP_ID", ""))
-            with gr.Row(): # New row for Translation API Key
-                with gr.Column():
-                    cfg_translation_key = gr.Textbox(
-                        label="Translation API Key (e.g., for Google Translate)", 
-                        type="password", 
-                        lines=1, 
-                        value=os.getenv("TRANSLATION_API_KEY", "")
-                    )
-                with gr.Column(): # Empty column to maintain layout if needed, or add other settings
-                    pass
+            # Removed the Row that contained cfg_translation_key
             
             gr.Markdown("API keys and other configurations are primarily managed via the `.env` file or environment variables. Changes made here are for the current session only unless your environment variables are updated externally.")
 

--- a/translator.py
+++ b/translator.py
@@ -1,110 +1,163 @@
 import logging
-from google.cloud import translate_v2 as translate # Import Google Cloud Translate library
+import requests
+import json
 
 logger = logging.getLogger(__name__)
 
-# Placeholder for actual API client or request logic - Now implementing Google Cloud Translate
-# For now, this module will simulate translation. - No longer simulating
-
-def translate_text(text: str, target_lang_code: str, source_lang_code: str = "auto", api_key: str = None) -> dict:
+def translate_text(text: str, target_lang_code: str, source_lang_code: str = "auto", 
+                   ollama_model: str = "llama3", 
+                   ollama_api_url: str = "http://localhost:11434") -> dict:
     """
-    Translates text using the Google Cloud Translation API.
+    Translates text using a local Ollama API.
 
     Args:
         text (str): The text to translate.
-        target_lang_code (str): The target language code (e.g., "en", "zh").
+        target_lang_code (str): The target language code (e.g., "en", "zh", "es", "fr").
         source_lang_code (str, optional): The source language code. Defaults to "auto".
-                                         If "auto", Google will attempt to detect the source language.
-        api_key (str, optional): API key. Note: Google Cloud client libraries typically use
-                                 Application Default Credentials (ADC) or a service account JSON
-                                 file specified by GOOGLE_APPLICATION_CREDENTIALS. This parameter
-                                 is logged but not directly used for client instantiation if ADC is active.
+                                         If "auto", the prompt will reflect this.
+        ollama_model (str, optional): The Ollama model to use for translation.
+        ollama_api_url (str, optional): The base URL for the Ollama API.
 
     Returns:
-        dict: A dictionary containing 'translated_text', 'error', and 'detected_source_language'.
-              e.g., {'translated_text': '...', 'error': None, 'detected_source_language': 'en'} or
-              {'translated_text': None, 'error': 'Translation failed', 'detected_source_language': None}
+        dict: A dictionary containing 'translated_text' and 'error'.
+              e.g., {'translated_text': '...', 'error': None} or
+              {'translated_text': None, 'error': 'Translation failed'}
     """
-    logger.info(f"Attempting to translate text to target language: {target_lang_code} using Google Cloud Translation.")
+    logger.info(f"Attempting to translate text to target language: {target_lang_code} using Ollama model: {ollama_model}.")
     logger.debug(f"Received text for translation (first 100 chars): {text[:100]}")
-    logger.debug(f"Target language: {target_lang_code}, Source language: {source_lang_code}")
-
-    if api_key:
-        logger.info("API key provided (note: Google Cloud client library typically uses ADC or GOOGLE_APPLICATION_CREDENTIALS env var).")
-
-    try:
-        translate_client = translate.Client()
-    except Exception as e:
-        logger.error(f"Failed to initialize Google Translate client: {e}", exc_info=True)
-        return {'translated_text': None, 'error': f"Failed to initialize Google Translate client: {e}", 'detected_source_language': None}
+    logger.debug(f"Target language: {target_lang_code}, Source language: {source_lang_code}, Model: {ollama_model}, URL: {ollama_api_url}")
 
     if not text:
-        return {'translated_text': "", 'error': None, 'detected_source_language': None}
+        return {'translated_text': "", 'error': None}
+
+    if not ollama_api_url:
+        return {'translated_text': None, 'error': "Ollama API URL not provided."}
+    if not ollama_model:
+        return {'translated_text': None, 'error': "Ollama model not specified."}
+
+    # Ensure the URL has a scheme
+    if not ollama_api_url.startswith(('http://', 'https://')):
+        ollama_api_url = 'http://' + ollama_api_url
+
+    # Construct the prompt
+    source_lang_display = "the source language (auto-detected if not specified)"
+    if source_lang_code and source_lang_code.lower() != "auto":
+        source_lang_display = f"'{source_lang_code}'"
+    
+    # Basic mapping for target language display (can be expanded)
+    lang_map = {"en": "English", "zh": "Chinese", "es": "Spanish", "fr": "French"}
+    target_lang_display = lang_map.get(target_lang_code.lower(), f"'{target_lang_code}'")
+
+    prompt = f"Translate the following text from {source_lang_display} to {target_lang_display}. Output ONLY the translated text and nothing else:\n\n{text}\n\nTranslated text:"
+
+    payload = {
+        "model": ollama_model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "options": { # Adding some options to potentially improve consistency for translation
+            "temperature": 0.2, # Lower temperature for more deterministic output
+        }
+    }
+    
+    chat_api_url = f"{ollama_api_url.rstrip('/')}/api/chat"
+    generate_api_url = f"{ollama_api_url.rstrip('/')}/api/generate" # Fallback
+    
+    logger.debug(f"Attempting Ollama translation with model '{ollama_model}' via /api/chat at {chat_api_url}")
 
     try:
-        source_for_api = source_lang_code if source_lang_code != "auto" else None
-            
-        result = translate_client.translate(
-            text,
-            target_language=target_lang_code,
-            source_language=source_for_api
-        )
-        translated_text = result['translatedText']
-        detected_source_lang = result.get('detectedSourceLanguage', source_for_api)
-            
-        logger.info(f"Successfully translated text to {target_lang_code}. Detected source: {detected_source_lang or 'N/A'}.")
-        return {'translated_text': translated_text, 'error': None, 'detected_source_language': detected_source_lang}
+        response = requests.post(chat_api_url, json=payload, timeout=60)
+        response.raise_for_status()
+        response_data = response.json()
+        
+        if 'message' in response_data and 'content' in response_data['message']:
+            translated_text = response_data['message']['content'].strip()
+            logger.info(f"Ollama /api/chat translation successful for model '{ollama_model}'.")
+            return {'translated_text': translated_text, 'error': None}
+        elif 'response' in response_data: # Fallback for generate-like response from chat endpoint
+            translated_text = response_data['response'].strip()
+            logger.info(f"Ollama /api/chat (generate-like response) translation successful for model '{ollama_model}'.")
+            return {'translated_text': translated_text, 'error': None}
+        else:
+            logger.error(f"Unexpected response structure from Ollama /api/chat for model '{ollama_model}': {response_data}")
+            return {'translated_text': None, 'error': f"Unexpected response structure from Ollama /api/chat: {response_data}"}
 
-    except Exception as e:
-        logger.error(f"Google Cloud Translation API error: {e}", exc_info=True)
-        return {'translated_text': None, 'error': f"Google Cloud Translation API error: {e}", 'detected_source_language': None}
+    except requests.exceptions.RequestException as e_chat:
+        logger.warning(f"Ollama /api/chat failed for model '{ollama_model}': {e_chat}. Trying /api/generate...")
+        payload_generate = {
+            "model": ollama_model,
+            "prompt": prompt,
+            "stream": False,
+            "options": payload["options"] # Carry over options
+        }
+        logger.debug(f"Attempting Ollama /api/generate for model '{ollama_model}' at {generate_api_url}")
+        try:
+            response = requests.post(generate_api_url, json=payload_generate, timeout=60)
+            response.raise_for_status()
+            response_data = response.json()
+            if 'response' in response_data:
+                translated_text = response_data['response'].strip()
+                logger.info(f"Ollama /api/generate translation successful for model '{ollama_model}'.")
+                return {'translated_text': translated_text, 'error': None}
+            else:
+                logger.error(f"Unexpected response structure from Ollama /api/generate for model '{ollama_model}': {response_data}")
+                return {'translated_text': None, 'error': f"Unexpected response structure from Ollama /api/generate: {response_data}"}
+        except requests.exceptions.RequestException as e_generate:
+            logger.error(f"Ollama API request failed for both /api/chat and /api/generate for model '{ollama_model}'. Chat error: {e_chat}. Generate error: {e_generate}", exc_info=True)
+            return {'translated_text': None, 'error': f"Ollama API request failed for both /api/chat and /api/generate. Chat error: {e_chat}. Generate error: {e_generate}"}
+    except json.JSONDecodeError as e_json:
+        logger.error(f"Failed to decode Ollama API response as JSON from {chat_api_url if 'e_chat' in locals() else generate_api_url}.", exc_info=True)
+        return {'translated_text': None, 'error': "Failed to decode Ollama API response as JSON."}
+    except Exception as e: # Catch-all for other unexpected errors
+        logger.error(f"An unexpected error occurred during Ollama translation: {e}", exc_info=True)
+        return {'translated_text': None, 'error': f"An unexpected error occurred: {e}"}
 
 
 if __name__ == '__main__':
-    # Basic setup for testing this module directly
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     
-    logger.info("NOTE: To run these tests effectively, ensure Google Cloud authentication is configured (e.g., GOOGLE_APPLICATION_CREDENTIALS environment variable).")
+    logger.info("NOTE: To run these tests effectively, ensure an Ollama instance is running with the specified model (e.g., 'llama3').")
+    logger.info("Default Ollama API URL: http://localhost:11434")
 
     sample_text_en = "Hello, world! This is a test of the translation module."
     sample_text_zh_src = "你好，世界！这是一个翻译模块的测试。"
+    ollama_test_model = "llama3" # Or your preferred model for testing
+    ollama_test_url = "http://localhost:11434"
 
-    # Test 1: English to Chinese (Real API call if auth is configured)
-    logger.info("\n--- Test 1: English to Chinese ---")
-    result1 = translate_text(sample_text_en, target_lang_code="zh", source_lang_code="en")
+    # Test 1: English to Chinese
+    logger.info("\n--- Test 1: English to Chinese (Ollama) ---")
+    result1 = translate_text(sample_text_en, target_lang_code="zh", source_lang_code="en", 
+                             ollama_model=ollama_test_model, ollama_api_url=ollama_test_url)
     if result1['error']:
         logger.error(f"Error: {result1['error']}")
     else:
-        logger.info(f"Original: {sample_text_en}")
-        logger.info(f"Translated: {result1['translated_text']}")
-        logger.info(f"Detected Source Language: {result1['detected_source_language']}")
+        logger.info(f"Original (EN): {sample_text_en}")
+        logger.info(f"Translated (ZH): {result1['translated_text']}")
 
-    # Test 2: Chinese to English (Real API call, auto-detect source)
-    logger.info("\n--- Test 2: Chinese to English (auto-detect source) ---")
-    result2 = translate_text(sample_text_zh_src, target_lang_code="en", source_lang_code="auto")
+    # Test 2: Chinese to English (auto-detect source)
+    logger.info("\n--- Test 2: Chinese to English (Ollama, source 'auto') ---")
+    result2 = translate_text(sample_text_zh_src, target_lang_code="en", source_lang_code="auto",
+                             ollama_model=ollama_test_model, ollama_api_url=ollama_test_url)
     if result2['error']:
         logger.error(f"Error: {result2['error']}")
     else:
-        logger.info(f"Original: {sample_text_zh_src}")
-        logger.info(f"Translated: {result2['translated_text']}")
-        logger.info(f"Detected Source Language: {result2['detected_source_language']}")
+        logger.info(f"Original (ZH): {sample_text_zh_src}")
+        logger.info(f"Translated (EN): {result2['translated_text']}")
 
     # Test 3: Empty text
-    logger.info("\n--- Test 3: Empty text ---")
-    result3 = translate_text("", target_lang_code="fr")
+    logger.info("\n--- Test 3: Empty text (Ollama) ---")
+    result3 = translate_text("", target_lang_code="fr", ollama_model=ollama_test_model, ollama_api_url=ollama_test_url)
     if result3['error']:
         logger.error(f"Error: {result3['error']}")
     else:
         logger.info(f"Original: ''")
         logger.info(f"Translated: '{result3['translated_text']}'")
-        logger.info(f"Detected Source Language: {result3['detected_source_language']}")
 
-    # Test 4: Translation to Spanish (auto-detect source)
-    logger.info("\n--- Test 4: English to Spanish (auto-detect source) ---")
-    result4 = translate_text(sample_text_en, target_lang_code="es") # Default source_lang_code="auto"
+    # Test 4: English to Spanish
+    logger.info("\n--- Test 4: English to Spanish (Ollama) ---")
+    result4 = translate_text(sample_text_en, target_lang_code="es", source_lang_code="en",
+                             ollama_model=ollama_test_model, ollama_api_url=ollama_test_url)
     if result4['error']:
         logger.error(f"Error: {result4['error']}")
     else:
-        logger.info(f"Original: {sample_text_en}")
-        logger.info(f"Translated: {result4['translated_text']}")
-        logger.info(f"Detected Source Language: {result4['detected_source_language']}")
+        logger.info(f"Original (EN): {sample_text_en}")
+        logger.info(f"Translated (ES): {result4['translated_text']}")


### PR DESCRIPTION
This commit refactors the translation functionality to use a local LLM service (Ollama) instead of the previously implemented Google Cloud Translation API.

Key changes:
-   `translator.py` has been rewritten to:
    -   Remove all Google Cloud Translation client logic.
    -   Construct prompts suitable for translation.
    -   Make API calls to an Ollama service endpoint (`/api/chat` or
        `/api/generate`).
    -   Accept Ollama API URL and model name as parameters.
    -   Parse Ollama responses and handle errors.
-   `app.py` (`handle_generate_audio_subtitles`) has been updated to:
    -   Call the new Ollama-based `translator.translate_text` function.
    -   Pass the existing Ollama configuration (API URL and model name,
        originally for summarization) to the translator.
    -   Remove the `TRANSLATION_API_KEY` from the call, as it's not
        used by the Ollama translator.
-   Configuration related to Google Cloud Translation API Key
    (`TRANSLATION_API_KEY`) has been removed from `app.py` (UI config
    tab, startup checks) and `.env.example` to reflect the shift to
    local LLM translation.

This change allows you to perform translations using your own local Ollama setup, providing more privacy and control over the translation process.