### PR TITLE
Fix: Update Minimax Chinese male voice ID to correct value

### DIFF
--- a/tts_generator.py
+++ b/tts_generator.py
@@ -54,7 +54,7 @@ MINIMAX_TTS_VOICE_MAPPING = {
     # This mapping needs to be based on available Minimax voice_ids.
     # Placeholder - update with actual valid voice_ids from Minimax documentation.
     "en": {"female": "female_en_voice", "male": "male_en_voice"},
-    "zh": {"female": "female_zh_voice", "male": "male_zh_voice"}, # Example: "female-zh-XiaoMei"
+    "zh": {"female": "female_zh_voice", "male": "male-qn-qingse"}, # Example: "female-zh-XiaoMei"
     # Defaulting to a known good Minimax voice if specific mapping isn't available,
     # but this might not match desired language/gender.
     # The example provided "male-qn-qingse" which seems to be Chinese Male.


### PR DESCRIPTION
The previous placeholder 'male_zh_voice' for Minimax Text-to-Speech caused an API error because the voice ID was invalid. This commit updates the `MINIMAX_TTS_VOICE_MAPPING` in `tts_generator.py` to use 'male-qn-qingse' for the Chinese male voice, which is believed to be a valid voice ID based on existing code comments and fallback logic. This change should resolve the 'tts_voice male_zh_voice not found' error when generating audio with Minimax for this voice configuration. Output: